### PR TITLE
CICD-60: Pinning to the 28 Sept Image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,8 @@ pipeline {
                         )
                     ]) {
                         sh 'cat $SSH_KEY_FILE > ssh_keys/id_rsa_packer'
-                        sh "curl --silent https://cloud-images.ubuntu.com/releases/bionic/release/SHA256SUMS | awk  '/ubuntu-18.04-server-cloudimg-amd64.img/ {print \$1}' > iso_256_checksum.txt" 
-                        sh 'sed -ie "s/REPLACE_THIS_WITH_ACTUAL_VALUE/$(cat iso_256_checksum.txt)/g" variables.json'
+                        sh "#curl --silent https://cloud-images.ubuntu.com/releases/bionic/release/SHA256SUMS | awk  '/ubuntu-18.04-server-cloudimg-amd64.img/ {print \$1}' > iso_256_checksum.txt" 
+                        sh '#sed -ie "s/REPLACE_THIS_WITH_ACTUAL_VALUE/$(cat iso_256_checksum.txt)/g" variables.json'
                     }                    
                 }
             }

--- a/variables.json
+++ b/variables.json
@@ -1,8 +1,8 @@
 {
     "disk_size": "12288",
   
-    "source_iso_url": "https://cloud-images.ubuntu.com/releases/bionic/release/ubuntu-18.04-server-cloudimg-amd64.img",
-    "source_iso_checksum": "REPLACE_THIS_WITH_ACTUAL_VALUE",
+    "source_iso_url": "https://cloud-images.ubuntu.com/releases/bionic/release-20210928/ubuntu-18.04-server-cloudimg-amd64.img",
+    "source_iso_checksum": "5c410839a4643372f7f7b6b8b54ad749b90b7900660dfc36dab443d4eb1abb8d",
   
     "output_vm_name": "ubuntu18.04_baseos.qcow2",
     "output_iso_checksum_path": "/tmp/ubuntu18.04_baseos_sha256.checksums",


### PR DESCRIPTION
Doing this due to the various issues with packer, the go ssh library, and openssh drop of sha1. 
This is all described with more detail in the JIRA. 
For now this will do. 
MM