### PR TITLE
Feature/CICD-77-get-ubuntu24-building

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
                             )
                     ]) {
                         sh 'make clean'
-                        sh 'make build'
+                        sh 'echo "make build"'
                     }
                 }
             }
@@ -47,10 +47,10 @@ pipeline {
                     sh 'cat $JENKINS_USER_KEY > ssh_keys/id_ed25519_jenkins'
                     sh 'chmod 600 ssh_keys/id_ed25519_jenkins'
                     sh 'sed -i -e \'/^$/d\' ssh_keys/id_ed25519_jenkins'
-                    sh 'rsync -a  --rsync-path="sudo rsync"  -e "ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins" output-ubuntu18.04_baseos/ubuntu18.04_baseos.qcow2 $JENKINS_USER_NAME@vmhost01:/zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2  --progress'
-                    sh 'ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost01 "sudo chown libvirt-qemu:kvm /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2"'
-                    sh 'rsync -a  --rsync-path="sudo rsync"  -e "ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins" output-ubuntu18.04_baseos/ubuntu18.04_baseos.qcow2 $JENKINS_USER_NAME@vmhost02:/zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2  --progress'
-                    sh 'ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost02 "sudo chown libvirt-qemu:kvm /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2"'
+                    sh '#rsync -a  --rsync-path="sudo rsync"  -e "ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins" output-ubuntu18.04_baseos/ubuntu18.04_baseos.qcow2 $JENKINS_USER_NAME@vmhost01:/zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2  --progress'
+                    sh '#ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost01 "sudo chown libvirt-qemu:kvm /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2"'
+                    sh '#rsync -a  --rsync-path="sudo rsync"  -e "ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins" output-ubuntu18.04_baseos/ubuntu18.04_baseos.qcow2 $JENKINS_USER_NAME@vmhost02:/zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2  --progress'
+                    sh '#ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost02 "sudo chown libvirt-qemu:kvm /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2"'
                 }
             }
         }
@@ -66,9 +66,9 @@ pipeline {
                     sh 'cat $JENKINS_USER_KEY > ssh_keys/id_ed25519_jenkins'
                     sh 'chmod 600 ssh_keys/id_ed25519_jenkins'
                     sh 'sed -i -e \'/^$/d\' ssh_keys/id_ed25519_jenkins'
-                    sh 'ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost01 "sudo mv /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2 /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_previous.qcow2"'
-                    sh 'ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost01 "sudo cp /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2 /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2"'
-                    sh 'ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost01 "sudo chown libvirt-qemu:kvm /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2"'
+                    sh '#ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost01 "sudo mv /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2 /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_previous.qcow2"'
+                    sh '#ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost01 "sudo cp /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2 /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2"'
+                    sh '#ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost01 "sudo chown libvirt-qemu:kvm /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2"'
                 }
             }
         }
@@ -84,9 +84,9 @@ pipeline {
                     sh 'cat $JENKINS_USER_KEY > ssh_keys/id_ed25519_jenkins'
                     sh 'chmod 600 ssh_keys/id_ed25519_jenkins'
                     sh 'sed -i -e \'/^$/d\' ssh_keys/id_ed25519_jenkins'
-                    sh 'ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost02 "sudo mv /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2 /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_previous.qcow2"'
-                    sh 'ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost02 "sudo cp /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2 /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2"'
-                    sh 'ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost02 "sudo chown libvirt-qemu:kvm /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2"'
+                    sh '#ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost02 "sudo mv /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2 /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_previous.qcow2"'
+                    sh '#ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost02 "sudo cp /zpools/vmhost_qcow/boot/ubuntu18.04_baseos_latest.qcow2 /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2"'
+                    sh '#ssh -o StrictHostKeyChecking=no -i ssh_keys/id_ed25519_jenkins $JENKINS_USER_NAME@vmhost02 "sudo chown libvirt-qemu:kvm /zpools/vmhost_qcow/boot/ubuntu18.04_baseos.qcow2"'
                 }
             }
         }
@@ -108,6 +108,7 @@ pipeline {
                             )
                     ]) {
                         sh 'make clean'
+                        sh 'make generate_iso'
                         sh 'make build_22'
                     }
                 }

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@ build:
 	PACKER_LOG=1 PACKER_LOG_PATH=build.log packer build  -var-file variables.json ubuntu18.04_baseos.json
 clean:
 	rm -rf output*
+	rm -rf cloud-init/ubuntu22.04_baseos/nocloud.iso
 
 build_22:
 	PACKER_LOG=1 PACKER_LOG_PATH=build-22.log packer build  -var-file variables-22.04.json ubuntu22.04_baseos.json
 
+generate_iso:
+	genisoimage -output cloud-init/ubuntu22.04_baseos/nocloud.iso -volid cidata -joliet -rock cloud-init/ubuntu22.04_baseos/user-data cloud-init/ubuntu22.04_baseos/meta-data
 
-all: build build_22 clean
+all: build generate_iso build_22 clean

--- a/cloud-init/ubuntu22.04_baseos/user-data
+++ b/cloud-init/ubuntu22.04_baseos/user-data
@@ -1,0 +1,10 @@
+#cloud-config
+users:
+  - name: packer
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh-authorized-keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDeHSzm1wkRFgHACYY2juoTeyRsAzHuZ/fBMbn7VVIKC7DyxzC/fPf+YkDCuBZTobsTipKSnBOrCpEPSjFuxTRqQtS626Dy2kVev7QB+4tF/jvOqk+7MlfvWxxWtg+KrZ+JjmWCQdNQTUtv3Ktm9cnPA34Zx7BZRd5l2RcaXoWIbwqB3PYCIemcLZZ6AgpZvJ4GQLEJWtwA41i3USq+LTPjYeFE4/53EVYT2Q3m3Io2OByl9hc0LGtXsZtWPGfC1QS0yEuTGtpqHdRPmmInj0Y201GeLNscNQt+jxU9ZozwX4c7RGX0qjw33ornbMyJVyMWIF7KYVxjvNcyfqPTKI8Q1eN+2x+5Hz4VaQLsqD5SrLMBuXCKOtVITPcdd2pFhTIW7rhUGIgL6qZ5sDT/UMQea7L4ql7ixgLGlHEY/DyhKipEq4kbsMW9vOoaQ/x7kaFnnSAOrYE3zG77slMqQuN4dIWZ6r0/FD2ZwS6PzU6OJ4+J1ZQgd/r6aQua+xGfRY/x3AgnERFYp+qOh4CyJs9o6k1H0LNhD1xeoj0acPa3F0Uo6ghFwweLFsek5gL1aOtdqHjPu9HzfGhL8QGS+vjIRPf+jnGvfjLCl5g9kcfQW3QEh/DvfsZAIaQjEzZNr6ULs8q90qaGGg+TEcGsv+yTJqAMe3m27RwkVNC2HDf/dQ== michalis.michaloliakos@gmail.com
+    uid: 999
+    no_create_home: false
+apt:
+  preserve_sources_list: true

--- a/ubuntu22.04_baseos.json
+++ b/ubuntu22.04_baseos.json
@@ -25,12 +25,8 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; sudo -S sh '/tmp/shutdown.sh'",
-      "http_directory": "cloud-init/ubuntu18.04_baseos",
       "qemuargs": [
-        [
-          "-smbios",
-          "type=1,serial=ds=nocloud-net;instance-id=packer;seedfrom=http://{{ .HTTPIP }}:{{ .HTTPPort }}/"
-        ]
+        [ "-cdrom", "cloud-init/ubuntu22.04_baseos/nocloud.iso" ]
       ]
     }
   ]


### PR DESCRIPTION
This PR disables ubuntu18 build to gain time and just allows for the building of ubuntu22

I will re-enable ubuntu18 if it works but quite possibly this fixes the issue with the ubuntu18 build process so I'll be updating this later on. 
MM