### PR TITLE
Feature/CICD-77-use-iso-for-ubuntu18

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,8 @@ pipeline {
                             )
                     ]) {
                         sh 'make clean'
-                        sh 'echo "make build"'
+                        sh 'make generate_iso'
+                        sh 'make build'
                     }
                 }
             }
@@ -108,8 +109,8 @@ pipeline {
                             )
                     ]) {
                         sh 'make clean'
-                        sh 'make generate_iso'
-                        sh 'make build_22'
+                        sh 'echo "make generate_iso"'
+                        sh 'echo "make build_22"'
                     }
                 }
             }

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,14 @@ build:
 clean:
 	rm -rf output*
 	rm -rf cloud-init/ubuntu22.04_baseos/nocloud.iso
+	rm -rf cloud-init/ubuntu18.04_baseos/nocloud.iso
+
 
 build_22:
 	PACKER_LOG=1 PACKER_LOG_PATH=build-22.log packer build  -var-file variables-22.04.json ubuntu22.04_baseos.json
 
 generate_iso:
 	genisoimage -output cloud-init/ubuntu22.04_baseos/nocloud.iso -volid cidata -joliet -rock cloud-init/ubuntu22.04_baseos/user-data cloud-init/ubuntu22.04_baseos/meta-data
+	genisoimage -output cloud-init/ubuntu18.04_baseos/nocloud.iso -volid cidata -joliet -rock cloud-init/ubuntu18.04_baseos/user-data cloud-init/ubuntu18.04_baseos/meta-data
 
 all: build generate_iso build_22 clean

--- a/cloud-init/ubuntu18.04_baseos/user-data
+++ b/cloud-init/ubuntu18.04_baseos/user-data
@@ -5,8 +5,6 @@ users:
     ssh-authorized-keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDeHSzm1wkRFgHACYY2juoTeyRsAzHuZ/fBMbn7VVIKC7DyxzC/fPf+YkDCuBZTobsTipKSnBOrCpEPSjFuxTRqQtS626Dy2kVev7QB+4tF/jvOqk+7MlfvWxxWtg+KrZ+JjmWCQdNQTUtv3Ktm9cnPA34Zx7BZRd5l2RcaXoWIbwqB3PYCIemcLZZ6AgpZvJ4GQLEJWtwA41i3USq+LTPjYeFE4/53EVYT2Q3m3Io2OByl9hc0LGtXsZtWPGfC1QS0yEuTGtpqHdRPmmInj0Y201GeLNscNQt+jxU9ZozwX4c7RGX0qjw33ornbMyJVyMWIF7KYVxjvNcyfqPTKI8Q1eN+2x+5Hz4VaQLsqD5SrLMBuXCKOtVITPcdd2pFhTIW7rhUGIgL6qZ5sDT/UMQea7L4ql7ixgLGlHEY/DyhKipEq4kbsMW9vOoaQ/x7kaFnnSAOrYE3zG77slMqQuN4dIWZ6r0/FD2ZwS6PzU6OJ4+J1ZQgd/r6aQua+xGfRY/x3AgnERFYp+qOh4CyJs9o6k1H0LNhD1xeoj0acPa3F0Uo6ghFwweLFsek5gL1aOtdqHjPu9HzfGhL8QGS+vjIRPf+jnGvfjLCl5g9kcfQW3QEh/DvfsZAIaQjEzZNr6ULs8q90qaGGg+TEcGsv+yTJqAMe3m27RwkVNC2HDf/dQ== michalis.michaloliakos@gmail.com
     uid: 999
-    system: true
     no_create_home: false
 apt:
   preserve_sources_list: true
-  package_update: false

--- a/ubuntu18.04_baseos.json
+++ b/ubuntu18.04_baseos.json
@@ -25,12 +25,8 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; sudo -S sh '/tmp/shutdown.sh'",
-      "http_directory": "cloud-init/ubuntu18.04_baseos",
       "qemuargs": [
-        [
-          "-smbios",
-          "type=1,serial=ds=nocloud-net;instance-id=packer;seedfrom=http://{{ .HTTPIP }}:{{ .HTTPPort }}/"
-        ]
+        [ "-cdrom", "cloud-init/ubuntu22.04_baseos/nocloud.iso" ]
       ]
     }
   ],

--- a/variables.json
+++ b/variables.json
@@ -1,8 +1,8 @@
 {
     "disk_size": "24576",
   
-    "source_iso_url": "https://cloud-images.ubuntu.com/releases/bionic/release-20210928/ubuntu-18.04-server-cloudimg-amd64.img",
-    "source_iso_checksum": "5c410839a4643372f7f7b6b8b54ad749b90b7900660dfc36dab443d4eb1abb8d",
+    "source_iso_url": "https://cloud-images.ubuntu.com/releases/bionic/release-20230607/ubuntu-18.04-server-cloudimg-amd64.img",
+    "source_iso_checksum": "8dd2e6b5e5aad20c3f836123b300cba9861249408cbb07c359145a65d6bab6b6",
   
     "output_vm_name": "ubuntu18.04_baseos.qcow2",
     "output_iso_checksum_path": "/tmp/ubuntu18.04_baseos_sha256.checksums",


### PR DESCRIPTION
This again is a temporary change. Since the new user-data and the nocloud.sio fix ubuntu22 , there's a disctinct chance it's fixing ubuntu18 as well. 
Let's try it